### PR TITLE
Add service type LoadBalancer

### DIFF
--- a/charts/maildev/Chart.yaml
+++ b/charts/maildev/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maildev
 description: MailDev is a simple way to test your emails during development with an easy to use web interface.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "2.1.0"
 home: https://github.com/alluen/maildev-helm
 maintainers:

--- a/charts/maildev/templates/smtp/service.yaml
+++ b/charts/maildev/templates/smtp/service.yaml
@@ -3,7 +3,11 @@ kind: Service
 metadata:
   name: {{ include "maildev.smtp.serviceName" . }}
   labels:
-    {{- include "maildev.labels" . | nindent 4 }}s
+    {{- include "maildev.labels" . | nindent 4 }}
+  {{- if .Values.services.smtp.annotations }}
+  annotations:
+    {{- toYaml .Values.services.smtp.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.services.smtp.type }}
   ports:
@@ -11,10 +15,11 @@ spec:
       targetPort: smtp
       protocol: TCP
       name: smtp
-      {{- if (eq .Values.services.smtp.type "NodePort") }}
-      {{- if .Values.services.smtp.nodePort }}
+      {{- if and (eq .Values.services.smtp.type "NodePort") .Values.services.smtp.nodePort }}
       nodePort: {{ .Values.services.smtp.nodePort }}
       {{- end }}
-      {{- end }}
+  {{- if and (eq .Values.services.smtp.type "LoadBalancer") .Values.services.smtp.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.services.smtp.loadBalancerIP | quote }}
+  {{- end }}
   selector:
     {{- include "maildev.selectorLabels" . | nindent 4 }}

--- a/charts/maildev/values.schema.json
+++ b/charts/maildev/values.schema.json
@@ -359,13 +359,19 @@
                     "type": "object",
                     "properties": {
                         "nodePort": {
-                            "type": "integer"
+                            "type": "string"
                         },
                         "port": {
                             "type": "integer"
                         },
                         "type": {
                             "type": "string"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/maildev/values.yaml
+++ b/charts/maildev/values.yaml
@@ -68,12 +68,16 @@ services:
     # -- Kubernetes port to use for the web GUI
     port: 1080
   smtp:
-    # -- Kubernetes service type for the SMTP server
+    # -- Kubernetes service type for the SMTP server. One of NodePort, LoadBalancer, or ClusterIP
     type: ClusterIP
     # -- Kubernetes port to use for the internal SMTP server
     port: 1025
     # -- You can set the node port for the external SMTP server that should be used or leave it blank to get a random node port. Only active if `services.smtp.type == NodePort`
-    nodePort:
+    nodePort: "" 
+    # -- Annotations to be added to the service
+    annotations: {}
+    # -- loadBalancerIP if services.smtp.type is LoadBalancer
+    loadBalancerIP: ""
 
 ingress:
   # -- Enable ingress record generation


### PR DESCRIPTION
Type `LoadBalancer` is required for using the MetalLB (to expose SMTP port outside of K8s).